### PR TITLE
made mmal priority

### DIFF
--- a/videosourceplugin.c
+++ b/videosourceplugin.c
@@ -13,15 +13,15 @@ void video_source_plugins_init(struct context *cnt) {
 
     struct config *conf = &cnt->conf;
 
-    if (conf->filecam_path) {
-        filecam_select_as_plugin(cnt);
-        return;
-    }
 #ifdef HAVE_MMAL
     if (conf->mmalcam_name) {
         mmalcam_select_as_plugin(cnt);
         return;
     }
 #endif
+    if (conf->filecam_path) {
+        filecam_select_as_plugin(cnt);
+        return;
+    }
 }
 


### PR DESCRIPTION
motioneye expects a videosource config entry to enumerate cameras, this allows you to override the source to use the mmalcam api in the additional settings.
